### PR TITLE
Implementation of #13 - Named Backpacks.

### DIFF
--- a/src/main/java/com/kwpugh/simple_backpack/Backpack.java
+++ b/src/main/java/com/kwpugh/simple_backpack/Backpack.java
@@ -50,8 +50,9 @@ public class Backpack implements ModInitializer
             final ItemStack stack = buf.readItemStack();
             final Hand hand = buf.readInt() == 0 ? Hand.MAIN_HAND : Hand.OFF_HAND;
             final BackpackInventoryInterface inventory = BackpackItem.getInventory(stack, hand, player);
+            final String customTitle = buf.readString();
 
-            return new BackpackScreenHandler(syncId, player.getInventory(), inventory.getInventory(), inventory.getInventoryWidth(), inventory.getInventoryHeight(), hand);
+            return new BackpackScreenHandler(syncId, player.getInventory(), inventory.getInventory(), inventory.getInventoryWidth(), inventory.getInventoryHeight(), hand, customTitle);
         }));
 
         ContainerProviderRegistry.INSTANCE.registerFactory(VOID_PACK_IDENTIFIER, ((syncId, identifier, player, buf) -> {

--- a/src/main/java/com/kwpugh/simple_backpack/backpack/BackpackClientScreen.java
+++ b/src/main/java/com/kwpugh/simple_backpack/backpack/BackpackClientScreen.java
@@ -7,6 +7,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
@@ -18,7 +19,7 @@ public class BackpackClientScreen extends HandledScreen<BackpackScreenHandler>
 
 	   public BackpackClientScreen(BackpackScreenHandler handler, PlayerInventory inventory, Text title)
 	   {
-	      super(handler, inventory, title);
+	      super(handler, inventory, handler.customTitle.isEmpty() ? title : new LiteralText(handler.customTitle));
 	      this.passEvents = false;
 	      this.rows = 6;
 	      this.backgroundHeight = 114 + this.rows * 18;

--- a/src/main/java/com/kwpugh/simple_backpack/backpack/BackpackItem.java
+++ b/src/main/java/com/kwpugh/simple_backpack/backpack/BackpackItem.java
@@ -30,8 +30,10 @@ public class BackpackItem extends Item
         if(!world.isClient)
         {
             ContainerProviderRegistry.INSTANCE.openContainer(Backpack.BACKPACK_IDENTIFIER, user, buf -> {
-                buf.writeItemStack(user.getStackInHand(hand));
+                ItemStack stack = user.getStackInHand(hand);
+                buf.writeItemStack(stack);
                 buf.writeInt(hand == Hand.MAIN_HAND ? 0 : 1);
+                buf.writeString(stack.getName().asString());
             });
         }
 

--- a/src/main/java/com/kwpugh/simple_backpack/backpack/BackpackScreenHandler.java
+++ b/src/main/java/com/kwpugh/simple_backpack/backpack/BackpackScreenHandler.java
@@ -18,16 +18,18 @@ public class BackpackScreenHandler extends ScreenHandler
     private final PlayerInventory playerInventory;
     public final int inventoryWidth;
     public final int inventoryHeight;
+    public final String customTitle;
 
     //private ItemStack backpack;
 
-    public BackpackScreenHandler(final int syncId, final PlayerInventory playerInventory, final Inventory inventory, final int inventoryWidth, final int inventoryHeight, final Hand hand)
+    public BackpackScreenHandler(final int syncId, final PlayerInventory playerInventory, final Inventory inventory, final int inventoryWidth, final int inventoryHeight, final Hand hand, String customTitle)
     {
         super(null, syncId);
         this.inventory = inventory;
         this.playerInventory = playerInventory;
         this.inventoryWidth = inventoryWidth;
         this.inventoryHeight = inventoryHeight;
+        this.customTitle = customTitle;
 
         checkSize(inventory, inventoryWidth * inventoryHeight);
         inventory.onOpen(playerInventory.player);


### PR DESCRIPTION
# Done:

This PR makes the **Simple Backpacks** have custom GUI titles when renamed on an anvil, suggested in #13 .

# Example:

![image](https://user-images.githubusercontent.com/52864251/127928866-ba602995-b2a4-46f1-b1cb-fc9de649b4dd.png)
![image](https://user-images.githubusercontent.com/52864251/127929011-62d34ea2-25a7-4632-b7f4-f03d13a66bab.png)
